### PR TITLE
Pin deps to specific version

### DIFF
--- a/templates/source.ejs
+++ b/templates/source.ejs
@@ -25,8 +25,8 @@
     </pre>
     <pre id="code"><code class="language-js"><%- src %></code></pre>
     </div>
-    <script src="https://unpkg.com/@popperjs/core@2" integrity="sha384-W8fXfP3gkOKtndU4JGtKDvXbO53Wy8SZCQHczT5FMiiqmQfUpWbYdTil/SxwZgAN" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/tippy.js@6" integrity="sha384-vJRz16GTXNh0rYTtwJHOvYKAak1mFPGhLKTioEv5FQz+vxPy/UK77RAjCyUIHFGB" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@popperjs/core@2.10.1" integrity="sha384-W8fXfP3gkOKtndU4JGtKDvXbO53Wy8SZCQHczT5FMiiqmQfUpWbYdTil/SxwZgAN" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/tippy.js@6.3.1" integrity="sha384-vJRz16GTXNh0rYTtwJHOvYKAak1mFPGhLKTioEv5FQz+vxPy/UK77RAjCyUIHFGB" crossorigin="anonymous"></script>
     <script src="<%= distPath %>main.js?v=<%= (new Date()).valueOf() %>"></script>
   </body>
 </html>


### PR DESCRIPTION
The updated tippy and popper libs aren't loaded b/c they don't match the sha384 checksums.

To confirm
```bash
wget https://unpkg.com/@popperjs/core@2.10.1
shasum -b -a 384 core@2.10.1 | awk '{ print $1 }'| xxd -r -p | base64
```